### PR TITLE
gecko: simplify GSK integration

### DIFF
--- a/gecko/CMakeLists.txt
+++ b/gecko/CMakeLists.txt
@@ -16,7 +16,7 @@ string(SUBSTRING ${CONFIG_SOC_SERIES} 7 2 GECKO_SERIES_NUMBER)
 
 set(SILABS_GECKO_PART_NUMBER ${CONFIG_SOC_PART_NUMBER})
 
-if (${CONFIG_BOARD} STREQUAL "efr32_radio_brd4187c")
+if(CONFIG_BOARD_EFR32_RADIO_EFR32MG24B220F1536IM48)
   set(PRODUCT_NO "sdid215")
 endif()
 
@@ -25,14 +25,14 @@ if (${CONFIG_BOARD} STREQUAL "efr32xg24_dk2601b")
   set(PRODUCT_NO "sdid215")
 endif()
 
-if (${CONFIG_BOARD} STREQUAL "efr32bg22_brd4184a")
-  set(SILABS_GECKO_BOARD "brd4184a")
-  set(PRODUCT_NO "sdid205")
+if("${CONFIG_BOARD}" STREQUAL "efr32bg22_brd4184a")
+    set(SILABS_GECKO_BOARD "brd4184a")
+    set(PRODUCT_NO "sdid205")
 endif()
 
-if (${CONFIG_BOARD} STREQUAL "efr32bg22_brd4184b")
-  set(SILABS_GECKO_BOARD "brd4184b")
-  set(PRODUCT_NO "sdid205")
+if("${CONFIG_BOARD}" STREQUAL "efr32bg22_brd4184b")
+    set(SILABS_GECKO_BOARD "brd4184b")
+    set(PRODUCT_NO "sdid205")
 endif()
 
 if (${CONFIG_BOARD} STREQUAL "efr32bg27_brd2602a")

--- a/gecko/CMakeLists.txt
+++ b/gecko/CMakeLists.txt
@@ -16,22 +16,6 @@ string(SUBSTRING ${CONFIG_SOC_SERIES} 7 2 GECKO_SERIES_NUMBER)
 
 set(SILABS_GECKO_PART_NUMBER ${CONFIG_SOC_PART_NUMBER})
 
-if (${CONFIG_BOARD} STREQUAL "efr32xg24_dk2601b")
-  set(SILABS_GECKO_BOARD "brd2601b")
-endif()
-
-if("${CONFIG_BOARD}" STREQUAL "efr32bg22_brd4184a")
-    set(SILABS_GECKO_BOARD "brd4184a")
-endif()
-
-if("${CONFIG_BOARD}" STREQUAL "efr32bg22_brd4184b")
-    set(SILABS_GECKO_BOARD "brd4184b")
-endif()
-
-if (${CONFIG_BOARD} STREQUAL "efr32bg27_brd2602a")
-  set(SILABS_GECKO_BOARD "brd2602a")
-endif()
-
 function(add_prebuilt_library lib_name prebuilt_path)
   add_library(${lib_name} STATIC IMPORTED GLOBAL)
   set_target_properties(${lib_name} PROPERTIES
@@ -102,8 +86,6 @@ endif()
 
 zephyr_include_directories(
   Device/SiliconLabs/${SILABS_GECKO_DEVICE}/Include
-  board/config/${SILABS_GECKO_BOARD}
-  board/inc
   common/inc
   emlib/inc
   service/device_init/config/s2

--- a/gecko/CMakeLists.txt
+++ b/gecko/CMakeLists.txt
@@ -16,28 +16,20 @@ string(SUBSTRING ${CONFIG_SOC_SERIES} 7 2 GECKO_SERIES_NUMBER)
 
 set(SILABS_GECKO_PART_NUMBER ${CONFIG_SOC_PART_NUMBER})
 
-if(CONFIG_BOARD_EFR32_RADIO_EFR32MG24B220F1536IM48)
-  set(PRODUCT_NO "sdid215")
-endif()
-
 if (${CONFIG_BOARD} STREQUAL "efr32xg24_dk2601b")
   set(SILABS_GECKO_BOARD "brd2601b")
-  set(PRODUCT_NO "sdid215")
 endif()
 
 if("${CONFIG_BOARD}" STREQUAL "efr32bg22_brd4184a")
     set(SILABS_GECKO_BOARD "brd4184a")
-    set(PRODUCT_NO "sdid205")
 endif()
 
 if("${CONFIG_BOARD}" STREQUAL "efr32bg22_brd4184b")
     set(SILABS_GECKO_BOARD "brd4184b")
-    set(PRODUCT_NO "sdid205")
 endif()
 
 if (${CONFIG_BOARD} STREQUAL "efr32bg27_brd2602a")
   set(SILABS_GECKO_BOARD "brd2602a")
-  set(PRODUCT_NO "sdid230")
 endif()
 
 function(add_prebuilt_library lib_name prebuilt_path)
@@ -115,7 +107,7 @@ zephyr_include_directories(
   common/inc
   emlib/inc
   service/device_init/config/s2
-  service/device_init/config/s2/${PRODUCT_NO}
+  service/device_init/config/s2/${CONFIG_SOC_GECKO_SDID}
   service/device_init/inc
   service/hfxo_manager/config
   service/hfxo_manager/inc


### PR DESCRIPTION
My PR on main repository allows Zephyr to export SDID. Thus, it is not more
needed to calculate it in CMakelists.txt.

